### PR TITLE
changed binary sensor over to check the relevant time

### DIFF
--- a/custom_components/revogi/binary_sensor.py
+++ b/custom_components/revogi/binary_sensor.py
@@ -1,4 +1,5 @@
 import asyncio
+from datetime import datetime, timedelta
 import hashlib
 import json
 import logging
@@ -54,6 +55,23 @@ class PetoneerSensor(CoordinatorEntity, BinarySensorEntity):
     @property
     def state(self):
         attributes = self.coordinator.data
+        filtertime = attributes[ATTR_FILTERTIME]
+        motortime =  attributes[ATTR_MOTORTIME]
+        watertime =  attributes[ATTR_WATERTIME]
         _LOGGER.debug(f"Binary Sensor state: {attributes}")
-        self._state = "on" if attributes['ledmode'] == 0 else "off"
+
+        filterdue = self.is_due(FILTER_DURATION, filtertime)
+        motordue = self.is_due(MOTOR_TIME, motortime)
+        waterdue = self.is_due(WATER_DURATION, watertime)
+
+        _LOGGER.debug(f"Filter due: {filterdue}")
+        _LOGGER.debug(f"Motor due: {motordue}")
+        _LOGGER.debug(f"Water due: {waterdue}")
+
+        self._state = "off" if (filterdue or motordue or waterdue) else "off"
         return self._state
+
+    def is_due(self, days, time):
+        due = datetime.now() + timedelta(days)
+        delta = due - datetime.fromtimestamp(time)
+        return delta.days < 0

--- a/custom_components/revogi/binary_sensor.py
+++ b/custom_components/revogi/binary_sensor.py
@@ -55,14 +55,11 @@ class PetoneerSensor(CoordinatorEntity, BinarySensorEntity):
     @property
     def state(self):
         attributes = self.coordinator.data
-        filtertime = attributes[ATTR_FILTERTIME]
-        motortime =  attributes[ATTR_MOTORTIME]
-        watertime =  attributes[ATTR_WATERTIME]
         _LOGGER.debug(f"Binary Sensor state: {attributes}")
 
-        filterdue = self.is_due(FILTER_DURATION, filtertime)
-        motordue = self.is_due(MOTOR_TIME, motortime)
-        waterdue = self.is_due(WATER_DURATION, watertime)
+        filterdue = self.is_due(FILTER_DURATION, attributes[ATTR_FILTERTIME])
+        motordue = self.is_due(MOTOR_TIME, attributes[ATTR_MOTORTIME])
+        waterdue = self.is_due(WATER_DURATION, attributes[ATTR_WATERTIME])
 
         _LOGGER.debug(f"Filter due: {filterdue}")
         _LOGGER.debug(f"Motor due: {motordue}")

--- a/custom_components/revogi/binary_sensor.py
+++ b/custom_components/revogi/binary_sensor.py
@@ -1,9 +1,9 @@
 import asyncio
-from datetime import datetime, timedelta
 import hashlib
 import json
 import logging
 import urllib.parse
+from datetime import datetime, timedelta
 
 import aiohttp
 import async_timeout

--- a/custom_components/revogi/const.py
+++ b/custom_components/revogi/const.py
@@ -13,3 +13,7 @@ CONF_SERIAL = "serial"
 CONF_USERNAME = "username"
 CONF_PASSWORD = "password"
 DEFAULT_NAME = "Petoneer Revogi"
+
+WATER_DURATION = 5
+FILTER_DURATION = 30
+MOTOR_TIME = 60


### PR DESCRIPTION
The binary sensor for alerting used to depend on the ledmode.
This is not reliable.

Instead the logic has been changed to check the last time each consumable was changed, and comparing it with the suggested duration in the fresco pro app