### PR TITLE
Handle when device is offline -- eg Wifi not connected etc

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
           - --configfile=tests/bandit.yaml
         files: ^(homeassistant|script)/.+\.py$
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,8 +25,8 @@ repos:
           - --quiet-level=2
         exclude_types: [csv, json, svg, pem, json]
         exclude: ^tests/fixtures/
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
+  - repo: https://github.com/pycqa/flake8.git
+    rev: 3.9.2
     hooks:
       - id: flake8
         additional_dependencies:

--- a/custom_components/revogi/binary_sensor.py
+++ b/custom_components/revogi/binary_sensor.py
@@ -62,12 +62,14 @@ class PetoneerBinarySensor(CoordinatorEntity, BinarySensorEntity):
     def state(self):
         attributes = self.coordinator.data
         _LOGGER.debug(f"Binary Sensor {self._name} state: {attributes}")
-        self._attrs = {
-            self._time: datetime.fromtimestamp(attributes[self._time]),
-            "service_days": self._duration
-        }
-        due = self.is_due(self._duration, attributes[self._time])
-        self._state = "on" if due  else "off"
+        self._state = "unknown"
+        if attributes:
+            self._attrs = {
+                self._time: datetime.fromtimestamp(attributes[self._time]),
+                "service_days": self._duration
+            }
+            due = self.is_due(self._duration, attributes[self._time])
+            self._state = "on" if due  else "off"
         return self._state
 
     def is_due(self, days, time):

--- a/custom_components/revogi/config_flow.py
+++ b/custom_components/revogi/config_flow.py
@@ -12,7 +12,7 @@ from .const import CONF_SERIAL, DOMAIN
 
 
 class RevogiFlowHandler(ConfigFlow, domain=DOMAIN):
-    """Handle a config flow for Solcast Solar."""
+    """Handle a config flow for Revogi."""
 
     VERSION = 2
 

--- a/custom_components/revogi/petoneer.py
+++ b/custom_components/revogi/petoneer.py
@@ -110,8 +110,11 @@ class Petoneer:
         json_resp = resp
 
         _LOGGER.debug(f"Device Response: {json_resp}")
-        device_details = json_resp['data']
-        _LOGGER.debug(f"Returning {device_details}")
+        if "data" in json_resp:
+            device_details = json_resp['data']
+            _LOGGER.debug(f"Returning {device_details}")
+        else:
+            device_details = False
         return device_details
 
     async def turn_on(self, device_code):

--- a/custom_components/revogi/sensor.py
+++ b/custom_components/revogi/sensor.py
@@ -61,18 +61,21 @@ class PetoneerSensor(CoordinatorEntity, SensorEntity):
 
         attributes = self.coordinator.data
         _LOGGER.debug(f"Sensor state: {attributes}")
-        self._attrs = {
-            ATTR_LEVEL: attributes['level'],
-            ATTR_TDS: attributes['tds'],
-            ATTR_LED: attributes['led'],
-            ATTR_LEDMODE: attributes['ledmode'],
-            ATTR_FILTERTIME: attributes[ATTR_FILTERTIME],
-            ATTR_MOTORTIME: attributes[ATTR_MOTORTIME],
-            ATTR_WATERTIME: attributes[ATTR_WATERTIME],
-            ATTR_ALARM: attributes['ledmode'] == 0,
-            ATTR_SWITCH: attributes['switch']
-        }
 
-        self._state = attributes['level'] * 25
+        if not attributes:
+            self._state = "unknown"
+        else:
+            self._attrs = {
+                ATTR_LEVEL: attributes['level'],
+                ATTR_TDS: attributes['tds'],
+                ATTR_LED: attributes['led'],
+                ATTR_LEDMODE: attributes['ledmode'],
+                ATTR_FILTERTIME: attributes[ATTR_FILTERTIME],
+                ATTR_MOTORTIME: attributes[ATTR_MOTORTIME],
+                ATTR_WATERTIME: attributes[ATTR_WATERTIME],
+                ATTR_ALARM: attributes['ledmode'] == 0,
+                ATTR_SWITCH: attributes['switch']
+            }
+            self._state = attributes['level'] * 25
 
         return self._state

--- a/custom_components/revogi/switch.py
+++ b/custom_components/revogi/switch.py
@@ -66,8 +66,10 @@ class PetoneerSwitch(CoordinatorEntity, SwitchEntity):
     @property
     def state(self):
         attributes = self.coordinator.data#.values()
-        self._state = attributes['switch']
-        state = "off"
+        state = "unknown"
+        if attributes:
+           self._state = attributes['switch']
+           state = "off"
         if (self._state == 1):
             state = "on"
         return state


### PR DESCRIPTION
Currently if the fountain is offline, the integration will set the relevant entities to unavaiable as they dont load correctly.


Instead, check for the expected API response, and set all the sensors to unknown if we dont get one.